### PR TITLE
Add AWS Terraform deployment stack parallel to existing GCP setup

### DIFF
--- a/AWS/README.md
+++ b/AWS/README.md
@@ -1,0 +1,31 @@
+# AWS Terraform deployment
+
+This directory contains an AWS-first Terraform deployment that mirrors the GCP architecture:
+
+- Cloud Run services -> ECS Fargate services (`modules/ecs_service`)
+- Pub/Sub topics -> Amazon Kinesis streams (`modules/kinesis`)
+- Secret Manager -> AWS Secrets Manager (`modules/secrets`)
+- Compute Engine Neo4j VM -> EC2 Neo4j instance (`modules/neo4j-db`)
+- VPC networking -> AWS VPC, subnets, NAT, and security groups (`modules/vpc`)
+
+## Usage
+
+```bash
+cd AWS
+terraform init
+terraform plan \
+  -var='neo4j_ami_id=ami-xxxxxxxx' \
+  -var='neo4j_password=change-me' \
+  -var='smtp_username=user' \
+  -var='smtp_password=pass' \
+  -var='pusher_key=key' \
+  -var='pusher_app_id=id' \
+  -var='pusher_cluster=cluster' \
+  -var='pusher_secret=secret' \
+  -var='auth0_client_id=id' \
+  -var='auth0_client_secret=secret' \
+  -var='auth0_domain=domain' \
+  -var='auth0_audience=audience'
+```
+
+> Note: update container images and IAM policies based on each microservice's final runtime requirements.

--- a/AWS/main.tf
+++ b/AWS/main.tf
@@ -1,0 +1,149 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile != "" ? var.aws_profile : null
+}
+
+locals {
+  resource_tags = merge(var.tags, {
+    environment = var.environment
+    application = "crawler"
+  })
+}
+
+module "vpc" {
+  source      = "./modules/vpc"
+  environment = var.environment
+  region      = var.region
+  tags        = local.resource_tags
+  vpc_cidr    = var.vpc_cidr
+}
+
+module "kinesis_streams" {
+  source      = "./modules/kinesis"
+  environment = var.environment
+  tags        = local.resource_tags
+  stream_names = [
+    "url",
+    "page_created",
+    "page_audit",
+    "journey_verified",
+    "journey_discarded",
+    "audit_error",
+    "audit_update",
+    "journey_candidate",
+    "journey_completion_cleanup"
+  ]
+}
+
+module "secrets" {
+  source      = "./modules/secrets"
+  environment = var.environment
+  tags        = local.resource_tags
+  secrets = {
+    neo4j_password      = var.neo4j_password
+    neo4j_username      = var.neo4j_username
+    neo4j_db_name       = var.neo4j_db_name
+    smtp_password       = var.smtp_password
+    smtp_username       = var.smtp_username
+    pusher_key          = var.pusher_key
+    pusher_app_id       = var.pusher_app_id
+    pusher_cluster      = var.pusher_cluster
+    pusher_secret       = var.pusher_secret
+    auth0_client_id     = var.auth0_client_id
+    auth0_client_secret = var.auth0_client_secret
+    auth0_domain        = var.auth0_domain
+    auth0_audience      = var.auth0_audience
+  }
+}
+
+module "neo4j_db" {
+  source               = "./modules/neo4j-db"
+  environment          = var.environment
+  tags                 = local.resource_tags
+  ami_id               = var.neo4j_ami_id
+  instance_type        = var.neo4j_instance_type
+  subnet_id            = module.vpc.private_subnet_ids[0]
+  vpc_security_group   = module.vpc.neo4j_security_group_id
+  key_name             = var.neo4j_key_name
+  neo4j_username       = var.neo4j_username
+  neo4j_password       = var.neo4j_password
+  neo4j_db_name        = var.neo4j_db_name
+}
+
+module "api_service" {
+  source                = "./modules/ecs_service"
+  environment           = var.environment
+  tags                  = local.resource_tags
+  service_name          = "api"
+  image                 = var.api_image
+  cluster_id            = module.vpc.ecs_cluster_id
+  subnet_ids            = module.vpc.private_subnet_ids
+  security_group_id     = module.vpc.ecs_service_security_group_id
+  execution_role_arn    = module.vpc.ecs_task_execution_role_arn
+  task_role_arn         = module.vpc.ecs_task_role_arn
+  region                = var.region
+  assign_public_ip      = false
+  environment_variables = {
+    URL_STREAM_NAME               = module.kinesis_streams.stream_names["url"]
+    JOURNEY_DISCARDED_STREAM_NAME = module.kinesis_streams.stream_names["journey_discarded"]
+    AUDIT_ERROR_STREAM_NAME       = module.kinesis_streams.stream_names["audit_error"]
+  }
+}
+
+module "page_builder_service" {
+  source                = "./modules/ecs_service"
+  environment           = var.environment
+  tags                  = local.resource_tags
+  service_name          = "page-builder"
+  image                 = var.page_builder_image
+  cluster_id            = module.vpc.ecs_cluster_id
+  subnet_ids            = module.vpc.private_subnet_ids
+  security_group_id     = module.vpc.ecs_service_security_group_id
+  execution_role_arn    = module.vpc.ecs_task_execution_role_arn
+  task_role_arn         = module.vpc.ecs_task_role_arn
+  region                = var.region
+  assign_public_ip      = false
+  environment_variables = {
+    PAGE_CREATED_STREAM_NAME   = module.kinesis_streams.stream_names["page_created"]
+    PAGE_AUDIT_STREAM_NAME     = module.kinesis_streams.stream_names["page_audit"]
+    JOURNEY_VERIFIED_STREAM    = module.kinesis_streams.stream_names["journey_verified"]
+    AUDIT_ERROR_STREAM_NAME    = module.kinesis_streams.stream_names["audit_error"]
+    NEO4J_URI                  = module.neo4j_db.bolt_uri
+    NEO4J_DB_SECRET_ARN        = module.secrets.secret_arns["neo4j_db_name"]
+    NEO4J_USER_SECRET_ARN      = module.secrets.secret_arns["neo4j_username"]
+    NEO4J_PASSWORD_SECRET_ARN  = module.secrets.secret_arns["neo4j_password"]
+  }
+}
+
+module "audit_manager_service" {
+  source                = "./modules/ecs_service"
+  environment           = var.environment
+  tags                  = local.resource_tags
+  service_name          = "audit-manager"
+  image                 = var.audit_manager_image
+  cluster_id            = module.vpc.ecs_cluster_id
+  subnet_ids            = module.vpc.private_subnet_ids
+  security_group_id     = module.vpc.ecs_service_security_group_id
+  execution_role_arn    = module.vpc.ecs_task_execution_role_arn
+  task_role_arn         = module.vpc.ecs_task_role_arn
+  region                = var.region
+  assign_public_ip      = false
+  environment_variables = {
+    PAGE_CREATED_STREAM_NAME = module.kinesis_streams.stream_names["page_created"]
+    PAGE_AUDIT_STREAM_NAME   = module.kinesis_streams.stream_names["page_audit"]
+    AUDIT_UPDATE_STREAM_NAME = module.kinesis_streams.stream_names["audit_update"]
+    AUDIT_ERROR_STREAM_NAME  = module.kinesis_streams.stream_names["audit_error"]
+    NEO4J_URI                = module.neo4j_db.bolt_uri
+  }
+}

--- a/AWS/modules/ecs_service/main.tf
+++ b/AWS/modules/ecs_service/main.tf
@@ -1,0 +1,58 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.environment}/${var.service_name}"
+  retention_in_days = 14
+  tags              = var.tags
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${var.environment}-${var.service_name}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.service_name
+      image     = var.image
+      essential = true
+      portMappings = [{
+        containerPort = var.port
+        hostPort      = var.port
+        protocol      = "tcp"
+      }]
+      environment = [for k, v in var.environment_variables : {
+        name  = k
+        value = v
+      }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = var.service_name
+        }
+      }
+    }
+  ])
+
+  tags = var.tags
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "${var.environment}-${var.service_name}"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.security_group_id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  tags = var.tags
+}

--- a/AWS/modules/ecs_service/outputs.tf
+++ b/AWS/modules/ecs_service/outputs.tf
@@ -1,0 +1,2 @@
+output "service_name" { value = aws_ecs_service.this.name }
+output "task_definition_arn" { value = aws_ecs_task_definition.this.arn }

--- a/AWS/modules/ecs_service/variables.tf
+++ b/AWS/modules/ecs_service/variables.tf
@@ -1,0 +1,16 @@
+variable "environment" { type = string }
+variable "tags" { type = map(string) default = {} }
+variable "service_name" { type = string }
+variable "image" { type = string }
+variable "cluster_id" { type = string }
+variable "subnet_ids" { type = list(string) }
+variable "security_group_id" { type = string }
+variable "execution_role_arn" { type = string }
+variable "task_role_arn" { type = string }
+variable "region" { type = string, default = "us-east-1" }
+variable "port" { type = number, default = 8080 }
+variable "cpu" { type = number, default = 512 }
+variable "memory" { type = number, default = 1024 }
+variable "desired_count" { type = number, default = 1 }
+variable "assign_public_ip" { type = bool, default = false }
+variable "environment_variables" { type = map(string), default = {} }

--- a/AWS/modules/kinesis/main.tf
+++ b/AWS/modules/kinesis/main.tf
@@ -1,0 +1,14 @@
+resource "aws_kinesis_stream" "this" {
+  for_each         = toset(var.stream_names)
+  name             = "${var.environment}-${each.value}"
+  shard_count      = 1
+  retention_period = 24
+
+  stream_mode_details {
+    stream_mode = "PROVISIONED"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${each.value}"
+  })
+}

--- a/AWS/modules/kinesis/outputs.tf
+++ b/AWS/modules/kinesis/outputs.tf
@@ -1,0 +1,7 @@
+output "stream_arns" {
+  value = { for name, stream in aws_kinesis_stream.this : name => stream.arn }
+}
+
+output "stream_names" {
+  value = { for name, stream in aws_kinesis_stream.this : name => stream.name }
+}

--- a/AWS/modules/kinesis/variables.tf
+++ b/AWS/modules/kinesis/variables.tf
@@ -1,0 +1,12 @@
+variable "environment" {
+  type = string
+}
+
+variable "stream_names" {
+  type = list(string)
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/AWS/modules/neo4j-db/main.tf
+++ b/AWS/modules/neo4j-db/main.tf
@@ -1,0 +1,23 @@
+locals {
+  user_data = templatefile("${path.module}/user_data.sh.tftpl", {
+    neo4j_username = var.neo4j_username
+    neo4j_password = var.neo4j_password
+    neo4j_db_name  = var.neo4j_db_name
+  })
+}
+
+resource "aws_instance" "neo4j" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.vpc_security_group]
+  key_name               = var.key_name
+  user_data              = local.user_data
+
+  root_block_device {
+    volume_size = 50
+    volume_type = "gp3"
+  }
+
+  tags = merge(var.tags, { Name = "${var.environment}-neo4j" })
+}

--- a/AWS/modules/neo4j-db/outputs.tf
+++ b/AWS/modules/neo4j-db/outputs.tf
@@ -1,0 +1,2 @@
+output "private_ip" { value = aws_instance.neo4j.private_ip }
+output "bolt_uri" { value = "bolt://${aws_instance.neo4j.private_ip}:7687" }

--- a/AWS/modules/neo4j-db/user_data.sh.tftpl
+++ b/AWS/modules/neo4j-db/user_data.sh.tftpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+apt-get update -y
+apt-get install -y wget gnupg
+wget -O - https://debian.neo4j.com/neotechnology.gpg.key | gpg --dearmor -o /usr/share/keyrings/neo4j.gpg
+echo "deb [signed-by=/usr/share/keyrings/neo4j.gpg] https://debian.neo4j.com stable latest" | tee /etc/apt/sources.list.d/neo4j.list
+apt-get update -y
+apt-get install -y neo4j
+sed -i 's/#dbms.default_listen_address=.*/dbms.default_listen_address=0.0.0.0/' /etc/neo4j/neo4j.conf
+neo4j-admin dbms set-initial-password "${neo4j_password}"
+systemctl enable neo4j
+systemctl restart neo4j

--- a/AWS/modules/neo4j-db/variables.tf
+++ b/AWS/modules/neo4j-db/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" { type = string }
+variable "tags" { type = map(string) default = {} }
+variable "ami_id" { type = string }
+variable "instance_type" { type = string }
+variable "subnet_id" { type = string }
+variable "vpc_security_group" { type = string }
+variable "key_name" { type = string, default = null }
+variable "neo4j_username" { type = string }
+variable "neo4j_password" { type = string, sensitive = true }
+variable "neo4j_db_name" { type = string }

--- a/AWS/modules/secrets/main.tf
+++ b/AWS/modules/secrets/main.tf
@@ -1,0 +1,11 @@
+resource "aws_secretsmanager_secret" "this" {
+  for_each = var.secrets
+  name     = "${var.environment}/${each.key}"
+  tags     = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  for_each      = var.secrets
+  secret_id     = aws_secretsmanager_secret.this[each.key].id
+  secret_string = each.value
+}

--- a/AWS/modules/secrets/outputs.tf
+++ b/AWS/modules/secrets/outputs.tf
@@ -1,0 +1,3 @@
+output "secret_arns" {
+  value = { for name, secret in aws_secretsmanager_secret.this : name => secret.arn }
+}

--- a/AWS/modules/secrets/variables.tf
+++ b/AWS/modules/secrets/variables.tf
@@ -1,0 +1,6 @@
+variable "environment" { type = string }
+variable "tags" { type = map(string) default = {} }
+variable "secrets" {
+  type      = map(string)
+  sensitive = true
+}

--- a/AWS/modules/vpc/main.tf
+++ b/AWS/modules/vpc/main.tf
@@ -1,0 +1,171 @@
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, { Name = "${var.environment}-vpc" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.environment}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, 0)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+  tags                    = merge(var.tags, { Name = "${var.environment}-public-subnet" })
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + 1)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  tags              = merge(var.tags, { Name = "${var.environment}-private-subnet-${count.index + 1}" })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags   = merge(var.tags, { Name = "${var.environment}-nat-eip" })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
+  tags          = merge(var.tags, { Name = "${var.environment}-nat" })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = merge(var.tags, { Name = "${var.environment}-public-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+  tags = merge(var.tags, { Name = "${var.environment}-private-rt" })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "ecs_service" {
+  name        = "${var.environment}-ecs-service-sg"
+  description = "Security group for ECS tasks"
+  vpc_id      = aws_vpc.this.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "neo4j" {
+  name        = "${var.environment}-neo4j-sg"
+  description = "Allow bolt traffic from ECS tasks"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = 7687
+    to_port         = 7687
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_service.id]
+  }
+
+  ingress {
+    from_port       = 7474
+    to_port         = 7474
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_service.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${var.environment}-looksee-cluster"
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+  tags = var.tags
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.environment}-ecs-task-execution-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.environment}-ecs-task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "ecs_task_inline" {
+  name = "${var.environment}-ecs-task-policy"
+  role = aws_iam_role.ecs_task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["kinesis:*", "secretsmanager:GetSecretValue", "ssm:GetParameter"]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/AWS/modules/vpc/outputs.tf
+++ b/AWS/modules/vpc/outputs.tf
@@ -1,0 +1,8 @@
+output "vpc_id" { value = aws_vpc.this.id }
+output "private_subnet_ids" { value = aws_subnet.private[*].id }
+output "public_subnet_id" { value = aws_subnet.public.id }
+output "ecs_cluster_id" { value = aws_ecs_cluster.this.id }
+output "ecs_service_security_group_id" { value = aws_security_group.ecs_service.id }
+output "neo4j_security_group_id" { value = aws_security_group.neo4j.id }
+output "ecs_task_execution_role_arn" { value = aws_iam_role.ecs_task_execution.arn }
+output "ecs_task_role_arn" { value = aws_iam_role.ecs_task.arn }

--- a/AWS/modules/vpc/variables.tf
+++ b/AWS/modules/vpc/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" { type = string }
+variable "region" { type = string }
+variable "vpc_cidr" { type = string }
+variable "tags" { type = map(string) default = {} }

--- a/AWS/outputs.tf
+++ b/AWS/outputs.tf
@@ -1,0 +1,23 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "private_subnet_ids" {
+  value = module.vpc.private_subnet_ids
+}
+
+output "kinesis_stream_arns" {
+  value = module.kinesis_streams.stream_arns
+}
+
+output "neo4j_private_ip" {
+  value = module.neo4j_db.private_ip
+}
+
+output "ecs_services" {
+  value = {
+    api          = module.api_service.service_name
+    page_builder = module.page_builder_service.service_name
+    audit_manager = module.audit_manager_service.service_name
+  }
+}

--- a/AWS/variables.tf
+++ b/AWS/variables.tf
@@ -1,0 +1,140 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "Optional shared credentials profile"
+  type        = string
+  default     = ""
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "tags" {
+  description = "Common resource tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "neo4j_ami_id" {
+  description = "AMI used by Neo4j EC2 instance"
+  type        = string
+}
+
+variable "neo4j_instance_type" {
+  description = "EC2 type for Neo4j"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "neo4j_key_name" {
+  description = "Optional key pair name for Neo4j host"
+  type        = string
+  default     = null
+}
+
+variable "neo4j_password" {
+  description = "Neo4j database password"
+  type        = string
+  sensitive   = true
+}
+
+variable "neo4j_username" {
+  description = "Neo4j database username"
+  type        = string
+  default     = "neo4j"
+}
+
+variable "neo4j_db_name" {
+  description = "Neo4j database name"
+  type        = string
+  default     = "neo4j"
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+  type        = string
+  sensitive   = true
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+  type        = string
+  sensitive   = true
+}
+
+variable "pusher_key" {
+  description = "Pusher key"
+  type        = string
+  sensitive   = true
+}
+
+variable "pusher_app_id" {
+  description = "Pusher app id"
+  type        = string
+}
+
+variable "pusher_cluster" {
+  description = "Pusher cluster"
+  type        = string
+}
+
+variable "pusher_secret" {
+  description = "Pusher secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_client_id" {
+  description = "Auth0 client id"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_client_secret" {
+  description = "Auth0 client secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_domain" {
+  description = "Auth0 domain"
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_audience" {
+  description = "Auth0 audience"
+  type        = string
+  sensitive   = true
+}
+
+variable "api_image" {
+  description = "API container image"
+  type        = string
+  default     = "docker.io/deepthought42/crawler-api:latest"
+}
+
+variable "page_builder_image" {
+  description = "Page builder container image"
+  type        = string
+  default     = "docker.io/deepthought42/page-builder:latest"
+}
+
+variable "audit_manager_image" {
+  description = "Audit manager container image"
+  type        = string
+  default     = "docker.io/deepthought42/audit-manager:latest"
+}


### PR DESCRIPTION
### Motivation
- Provide an AWS-first Terraform root that mirrors the existing GCP architecture so the platform can be deployed to AWS. 
- Replace GCP services with AWS equivalents: Cloud Run -> ECS Fargate, Pub/Sub -> Kinesis, Secret Manager -> AWS Secrets Manager, and Compute Engine Neo4j VM -> EC2. 
- Offer reusable, modular infrastructure to reduce duplication and make the multi-cloud deployment pattern explicit. 

### Description
- Added a new AWS root module (`AWS/`) with `AWS/main.tf`, `AWS/variables.tf`, `AWS/outputs.tf`, and `AWS/README.md` that wires together the AWS modules and provider configuration. 
- Implemented reusable modules: `AWS/modules/vpc` (VPC, subnets, NAT/IGW, route tables, SGs, ECS cluster, IAM roles), `AWS/modules/kinesis` (Kinesis streams), `AWS/modules/secrets` (Secrets Manager secrets/versions), `AWS/modules/neo4j-db` (EC2 + user-data bootstrap template), and `AWS/modules/ecs_service` (generic Fargate task/service with CloudWatch logging). 
- Added module outputs to expose VPC, subnet IDs, Kinesis stream ARNs, Neo4j private IP/bolt URI, and ECS service names, and passed `region = var.region` into ECS service module invocations. 
- Included a bootstrap `user_data.sh.tftpl` for Neo4j installation and a usage `README.md` for the AWS deployment. 

### Testing
- Ran `git status --short` and `git log -1 --oneline` to confirm files staged and committed successfully, and the commit included 20 files with 702 insertions. 
- Committed the changes with `git commit` which completed successfully. 
- Attempted to run `terraform fmt -recursive AWS` but it failed because the `terraform` CLI is not installed in the execution environment (`terraform: command not found`). 
- A web search attempt used `urllib.request` but was blocked by the network tunnel (`403 Forbidden`), so no external validation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98c0fa3bc832e8d68fa959c61d6bd)